### PR TITLE
Fix `REGISTRY_URL` not working

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -11,8 +11,7 @@ server {
     }
 
 #!    location /v2 {
-#!        set $upstream ${REGISTRY_URL};
-#!        proxy_pass $upstream;
+#!        proxy_pass ${REGISTRY_URL};
 #!    }
 
     #error_page  404              /404.html;


### PR DESCRIPTION
Tested with nginx version `1.13.8` and  docker image `joxit/docker-registry-ui:static`

Useful to know: https://serverfault.com/a/644898