### PR TITLE
Fix '403 Request Entity Too Large'

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -5,12 +5,23 @@ server {
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 
+    # disable any limits to avoid HTTP 413 for large image uploads
+    client_max_body_size 0;
+
+    # required to avoid HTTP 411: see Issue #1486 (https://github.com/moby/moby/issues/1486)
+    chunked_transfer_encoding on;
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
     }
 
 #!    location /v2 {
+#!        # Do not allow connections from docker 1.5 and earlier
+#!        # docker pre-1.6.0 did not properly set the user agent on ping, catch "Go *" user agents
+#!        if ($http_user_agent ~ "^(docker\/1\.(3|4|5(?!\.[0-9]-dev))|Go ).*$" ) {
+#!            return 404;
+#!        }
 #!        proxy_pass ${REGISTRY_URL};
 #!    }
 
@@ -30,4 +41,3 @@ server {
     #    deny  all;
     #}
 }
-


### PR DESCRIPTION
Hi,

Thank you very much for this wonderful image. Finally a good one who allows deleting images!
When pushing my images on my private registry, I met an error with nginx because the layer was about ~ 300 MB.

This fix intends to:
- Disable client_max_body_size to avoid the error '403 Request Entity Too Large' which prevent uploading "big" images.
- Apply recommended settings by Docker (https://docs.docker.com/registry/recipes/nginx)
