### PR TITLE
Init with the docker registry hosted on the same domain as UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,37 @@
-.project
-node_modules
+# dependencies
+/node_modules
 package-lock.json
+
+# IDEs and editors
+/.idea
+*.iml
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+# System Files
+.DS_Store
+Thumbs.db
+.vscode/
+
 registry-data

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,4 +13,4 @@
 
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
---><!DOCTYPE html><html><head><meta charset="UTF-8"><link rel="stylesheet" href="vendor.css"><link rel="stylesheet" href="style.css"><link href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en" rel="stylesheet" type="text/css"><title>Docker Registry UI</title></head><body><app></app><script src="scripts/vendor.js"></script><script src="scripts/docker-registry-ui.js"></script></body></html>
+--><!DOCTYPE html><html><head><meta charset="UTF-8"><link rel="stylesheet" href="vendor.css"><link rel="stylesheet" href="style.css"><link href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en" rel="stylesheet" type="text/css"><title>Docker Registry UI</title></head><body><app></app><script src="scripts/init.js"></script><script src="scripts/vendor.js"></script><script src="scripts/docker-registry-ui.js"></script></body></html>

--- a/dist/scripts/init.js
+++ b/dist/scripts/init.js
@@ -1,0 +1,27 @@
+const REGISTRY_SERVER_KEY = 'registryServer';
+let registryServersStr = localStorage.getItem(REGISTRY_SERVER_KEY);
+let registryServers = [];
+if (registryServersStr !== null){
+    let rs = JSON.parse(registryServersStr);
+    if (rs instanceof Array) {
+        registryServers = rs;
+    }
+}
+
+const apiHost = location.protocol+'//'+location.host;
+if (!registryServers.includes(apiHost)) {
+    let xhr = new XMLHttpRequest();
+    xhr.open('GET', apiHost+"/v2/", true);
+    xhr.onload = function (e) {
+        if (xhr.readyState === 4) {
+            if (xhr.status === 200) {
+                const version = xhr.getResponseHeader('Docker-Distribution-Api-Version');
+                if (version.startsWith('registry/2.')) {
+                    registryServers.unshift(apiHost);
+                    localStorage.setItem(REGISTRY_SERVER_KEY, JSON.stringify(registryServers));
+                }
+            }
+        }
+    };
+    xhr.send();
+}

--- a/src/index.html
+++ b/src/index.html
@@ -32,6 +32,7 @@
 
 <body>
   <app></app>
+  <script src="scripts/init.js"></script>
   <!-- build:js scripts/vendor.js -->
   <script src="../node_modules/riot/riot+compiler.min.js"></script>
   <script src="../node_modules/riot-route/dist/route.js"></script>

--- a/src/scripts/init.js
+++ b/src/scripts/init.js
@@ -1,0 +1,27 @@
+const REGISTRY_SERVER_KEY = 'registryServer';
+let registryServersStr = localStorage.getItem(REGISTRY_SERVER_KEY);
+let registryServers = [];
+if (registryServersStr !== null){
+    let rs = JSON.parse(registryServersStr);
+    if (rs instanceof Array) {
+        registryServers = rs;
+    }
+}
+
+const apiHost = location.protocol+'//'+location.host;
+if (!registryServers.includes(apiHost)) {
+    let xhr = new XMLHttpRequest();
+    xhr.open('GET', apiHost+"/v2/", true);
+    xhr.onload = function (e) {
+        if (xhr.readyState === 4) {
+            if (xhr.status === 200) {
+                const version = xhr.getResponseHeader('Docker-Distribution-Api-Version');
+                if (version.startsWith('registry/2.')) {
+                    registryServers.unshift(apiHost);
+                    localStorage.setItem(REGISTRY_SERVER_KEY, JSON.stringify(registryServers));
+                }
+            }
+        }
+    };
+    xhr.send();
+}


### PR DESCRIPTION
Thanks for this nice and simple UI 🥇 
I'm looking for app like this to run it on NGiNX server that is a reverse proxy for docker registry REST API.
It would be great if the app would automatically add a reference to the registry if it's running on the same domain as app.
I'm not a front-end programmer but I've proposed some solution - please take a look at my PR, maybe it will interest you:
- added `init.js` script that can be customized by provider
- added default implementation of `init.js` that detects if is running on the same host as API and if API's version is ok then it add to the beginning of servers array (localStorage)