### PR TITLE
fix docker network name

### DIFF
--- a/examples/ui-as-proxy/simple.yml
+++ b/examples/ui-as-proxy/simple.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ./registry-data:/var/lib/registry
     networks:
-      - docker-registry-ui
+      - registry-ui-net
 
   ui:
     image: joxit/docker-registry-ui:static
@@ -17,7 +17,7 @@ services:
     depends_on:
       - registry
     networks:
-      - docker-registry-ui
+      - registry-ui-net
 
 networks:
   registry-ui-net:


### PR DESCRIPTION
If I execute the following command, I get the error below. This PR fixes the issue.
```bash
docker-compose -f simple.yml up -d
```
>>>
WARNING: Some networks were defined but are not used by any service: registry-ui-net
ERROR: Service "registry" uses an undefined network "docker-registry-ui"