### PR TITLE
Supports custom headers when the ui is used as proxy

### DIFF
--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -1,5 +1,5 @@
 #!/bin/sh
-$@
+
 sed -i "s,\${URL},${URL}," scripts/docker-registry-ui.js
 sed -i "s,\${REGISTRY_TITLE},${REGISTRY_TITLE}," scripts/docker-registry-ui.js
 sed -i "s,\${PULL_URL},${PULL_URL}," scripts/docker-registry-ui.js
@@ -8,13 +8,25 @@ if [ -z "${DELETE_IMAGES}" ] || [ "${DELETE_IMAGES}" = false ] ; then
   sed -i -r "s/(isImageRemoveActivated[:=])[^,;]*/\1false/" scripts/docker-registry-ui.js
 fi
 
+get_nginx_proxy_headers() {
+  env | while read e; do
+    if [ -n "$(echo $e | grep -o '^NGINX_PROXY_HEADER_')" ]; then
+      key=$(echo ${e%%=*} | sed 's/^NGINX_PROXY_HEADER_//' | sed 's/_/-/g')
+      value=${e#*=}
+      echo "Add proxy header $key: $value" >&2
+      echo -n "proxy_set_header ${key} \"${value}\"; "
+    fi
+  done
+}
+
 if [ -n "${REGISTRY_URL}" ] ; then
   sed -i "s,\${REGISTRY_URL},${REGISTRY_URL}," /etc/nginx/conf.d/default.conf
+  sed -i "s^\${NGINX_PROXY_HEADERS}^$(get_nginx_proxy_headers)^" /etc/nginx/conf.d/default.conf
   sed -i "s,#!,," /etc/nginx/conf.d/default.conf
 fi
 
 if [ -z "$@" ]; then
-  nginx -g "daemon off;"
+  exec nginx -g "daemon off;"
 else
-  $@
+  exec $@
 fi

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -9,11 +9,17 @@ if [ -z "${DELETE_IMAGES}" ] || [ "${DELETE_IMAGES}" = false ] ; then
 fi
 
 get_nginx_proxy_headers() {
-  env | while read e; do
+  (
+    env &&
+    if [ -f "/etc/nginx/.env" ]; then
+      cat /etc/nginx/.env
+      # Force new line
+      echo ""
+    fi
+  ) | while read e; do
     if [ -n "$(echo $e | grep -o '^NGINX_PROXY_HEADER_')" ]; then
       key=$(echo ${e%%=*} | sed 's/^NGINX_PROXY_HEADER_//' | sed 's/_/-/g')
       value=${e#*=}
-      echo "Add proxy header $key: $value" >&2
       echo -n "proxy_set_header ${key} \"${value}\"; "
     fi
   done

--- a/examples/proxy-headers/README.md
+++ b/examples/proxy-headers/README.md
@@ -1,0 +1,22 @@
+# Set custom headers to the registry example
+
+The interface and the docker registry will be accessible with <http://localhost>.
+
+This example highlight the usage of custom headers when the UI is used as a proxy. When you wants to use a header name with hyphens, replace them by underscores in the variable.
+
+Headers can be useful in some cases such as avoid sending credentials when you are on the UI. Or give to the registry server other properties such as X-Forward-For header.
+
+I will set these two headers in this example.
+
+In order to set your credentials in the header, you need to know how [Authorization](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) header works. Here we use the `Basic` authentication scheme, the credentials are constructed like this:
+- The username and the password are combined with a colon (`registry:ui`).
+- The resulting string is base64 encoded (`cmVnaXN0cnk6dWk=`). You can simply run `echo -n "registry:ui" | base64`.
+- In your header, put this value `Basic cmVnaXN0cnk6dWk=`
+- In your docker-compose, the environment will look like `NGINX_PROXY_HEADER_Authorization=Basic cmVnaXN0cnk6dWk=`
+
+Tip: Use [docker-compose .env file](https://docs.docker.com/compose/environment-variables/#the-env-file) for this .
+
+
+For X-Forward-For, replace all hyphens by underscores, and the value will be a nginx variable which is `$proxy_add_x_forwarded_for`. In your docker compose you will need to duplicate the `$` character. In your docker-compose, your environment will look like `NGINX_PROXY_HEADER_X_Forwarded_For=$$proxy_add_x_forwarded_for`
+
+As usual, run the project with `docker-compose up -d` (for background mode)

--- a/examples/proxy-headers/README.md
+++ b/examples/proxy-headers/README.md
@@ -2,20 +2,17 @@
 
 The interface and the docker registry will be accessible with <http://localhost>.
 
-This example highlight the usage of custom headers when the UI is used as a proxy. When you wants to use a header name with hyphens, replace them by underscores in the variable.
+This example highlight the usage of custom headers when the UI is used as a proxy. When you wants to use a header name with hyphens, replace them by underscores in the variable. You can put headers in environment variable or in config file `/etc/nginx/.env`. They have the same writing style.
 
 Headers can be useful in some cases such as avoid sending credentials when you are on the UI. Or give to the registry server other properties such as X-Forward-For header.
 
-I will set these two headers in this example.
+I will set these two headers in this example. X-Forward-For by environment variable and Authorization by file.
 
 In order to set your credentials in the header, you need to know how [Authorization](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) header works. Here we use the `Basic` authentication scheme, the credentials are constructed like this:
 - The username and the password are combined with a colon (`registry:ui`).
 - The resulting string is base64 encoded (`cmVnaXN0cnk6dWk=`). You can simply run `echo -n "registry:ui" | base64`.
 - In your header, put this value `Basic cmVnaXN0cnk6dWk=`
-- In your docker-compose, the environment will look like `NGINX_PROXY_HEADER_Authorization=Basic cmVnaXN0cnk6dWk=`
-
-Tip: Use [docker-compose .env file](https://docs.docker.com/compose/environment-variables/#the-env-file) for this .
-
+- In your `/etc/nginx/.env`, the file will contains `NGINX_PROXY_HEADER_Authorization=Basic cmVnaXN0cnk6dWk=`
 
 For X-Forward-For, replace all hyphens by underscores, and the value will be a nginx variable which is `$proxy_add_x_forwarded_for`. In your docker compose you will need to duplicate the `$` character. In your docker-compose, your environment will look like `NGINX_PROXY_HEADER_X_Forwarded_For=$$proxy_add_x_forwarded_for`
 

--- a/examples/proxy-headers/docker-compose.yml
+++ b/examples/proxy-headers/docker-compose.yml
@@ -16,8 +16,9 @@ services:
     environment:
       - REGISTRY_TITLE=My Private Docker Registry
       - REGISTRY_URL=http://registry:5000
-      - NGINX_PROXY_HEADER_Authorization=Basic cmVnaXN0cnk6dWk=
       - NGINX_PROXY_HEADER_X_Forwarded_For=$$proxy_add_x_forwarded_for
+    volumes:
+      - ./nginx.env:/etc/nginx/.env
     depends_on:
       - registry
     networks:

--- a/examples/proxy-headers/docker-compose.yml
+++ b/examples/proxy-headers/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '2.0'
+services:
+  registry:
+    image: registry:2.7
+    volumes:
+      - ./registry-data:/var/lib/registry
+      - ./registry-config/credentials.yml:/etc/docker/registry/config.yml
+      - ./registry-config/htpasswd:/etc/docker/registry/htpasswd
+    networks:
+      - registry-ui-net
+
+  ui:
+    image: joxit/docker-registry-ui:static
+    ports:
+      - 80:80
+    environment:
+      - REGISTRY_TITLE=My Private Docker Registry
+      - REGISTRY_URL=http://registry:5000
+      - NGINX_PROXY_HEADER_Authorization=Basic cmVnaXN0cnk6dWk=
+      - NGINX_PROXY_HEADER_X_Forwarded_For=$$proxy_add_x_forwarded_for
+    depends_on:
+      - registry
+    networks:
+      - registry-ui-net
+
+networks:
+  registry-ui-net:

--- a/examples/proxy-headers/nginx.env
+++ b/examples/proxy-headers/nginx.env
@@ -1,0 +1,1 @@
+NGINX_PROXY_HEADER_Authorization=Basic cmVnaXN0cnk6dWk=

--- a/examples/proxy-headers/registry-config/credentials.yml
+++ b/examples/proxy-headers/registry-config/credentials.yml
@@ -1,0 +1,25 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  delete:
+    enabled: true
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+    Access-Control-Allow-Origin: ['http://localhost']
+    Access-Control-Allow-Methods: ['HEAD', 'GET', 'OPTIONS', 'DELETE']
+    Access-Control-Allow-Headers: ['Authorization']
+    Access-Control-Max-Age: [1728000]
+    Access-Control-Allow-Credentials: [true]
+    Access-Control-Expose-Headers: ['Docker-Content-Digest']
+auth:
+  htpasswd:
+    realm: basic-realm
+    path: /etc/docker/registry/htpasswd

--- a/examples/proxy-headers/registry-config/htpasswd
+++ b/examples/proxy-headers/registry-config/htpasswd
@@ -1,0 +1,1 @@
+registry:$2y$11$1bmuJLK8HrQl5ACS/WeqRuJLUArUZfUcP2R23asmozEpfN76.pCHy

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -25,6 +25,7 @@ server {
 #!            return 404;
 #!        }
 #!        proxy_set_header Host $http_host;
+#!        ${NGINX_PROXY_HEADERS}
 #!        proxy_pass ${REGISTRY_URL};
 #!    }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {},
   "devDependencies": {
     "del": "^3.0.0",
-    "gulp": "^4.0.1",
+    "gulp": "^4.0.2",
     "gulp-clean-css": "^4.2.0",
     "gulp-concat": "^2.6.0",
     "gulp-filter": "^5.1.0",


### PR DESCRIPTION
## Background

Headers can be useful in some cases such as avoid sending credentials when you are on the UI (like #87). Or give to the registry server other properties such as `X-Forward-For` or `Server` headers for monitoring.

## How to use ?

This is compatible only with static version of the UI and used with `REGISTRY_URL` variable.
When you want to add a custom header, add to the registry ui a environment variable or entry in `/etc/nginx/.env` which looks like `NGINX_PROXY_HEADER_Custom_Header`. All underscores (`_`) will be replaced by hyphens (`-`). 

Some example of custom headers as variable:
- `NGINX_PROXY_HEADER_Authorization` for Basic auth credentials
- `NGINX_PROXY_HEADER_X_Forwarded_For` for identifying the originating IP address of a client

An example is bundled with this PR

Any feedback @marcusblake ?

closes: #87