### PR TITLE
v2 api limit decreased

### DIFF
--- a/src/tags/catalog.tag
+++ b/src/tags/catalog.tag
@@ -68,7 +68,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         registryUI.catalog.loadend = true;
         registryUI.catalog.instance.update();
       });
-      oReq.open('GET', registryUI.url() + '/v2/_catalog?n=100000');
+      oReq.open('GET', registryUI.url() + '/v2/_catalog?n=1000');
       oReq.send();
     };
     registryUI.catalog.display();


### PR DESCRIPTION
Original value 100000 is too much for aws ecr, it will return error, there is a limit 1000. This value should be provided as option, at least during build time.