### PR TITLE
Use entrypoint mechanism from latest nginx images

### DIFF
--- a/arm32v7-static.dockerfile
+++ b/arm32v7-static.dockerfile
@@ -23,6 +23,4 @@ ENV NGINX_PROXY_HEADER_Host '$http_host'
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY dist/ /usr/share/nginx/html/
 COPY dist/scripts/docker-registry-ui-static.js /usr/share/nginx/html/scripts/docker-registry-ui.js
-COPY bin/entrypoint /bin
-
-ENTRYPOINT entrypoint
+COPY bin/entrypoint /docker-entrypoint.d/90-docker-registry-ui.sh

--- a/arm64v8-static.dockerfile
+++ b/arm64v8-static.dockerfile
@@ -23,6 +23,4 @@ ENV NGINX_PROXY_HEADER_Host '$http_host'
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY dist/ /usr/share/nginx/html/
 COPY dist/scripts/docker-registry-ui-static.js /usr/share/nginx/html/scripts/docker-registry-ui.js
-COPY bin/entrypoint /bin
-
-ENTRYPOINT entrypoint
+COPY bin/entrypoint /docker-entrypoint.d/90-docker-registry-ui.sh

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -38,9 +38,3 @@ if [ -n "${REGISTRY_URL}" ] ; then
   sed -i "s^\${NGINX_PROXY_HEADERS}^$(get_nginx_proxy_headers)^" /etc/nginx/conf.d/default.conf
   sed -i "s,#!,," /etc/nginx/conf.d/default.conf
 fi
-
-if [ -z "$@" ]; then
-  exec nginx -g "daemon off;"
-else
-  exec $@
-fi

--- a/debian-static.dockerfile
+++ b/debian-static.dockerfile
@@ -23,6 +23,4 @@ ENV NGINX_PROXY_HEADER_Host '$http_host'
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY dist/ /usr/share/nginx/html/
 COPY dist/scripts/docker-registry-ui-static.js /usr/share/nginx/html/scripts/docker-registry-ui.js
-COPY bin/entrypoint /bin
-
-ENTRYPOINT entrypoint
+COPY bin/entrypoint /docker-entrypoint.d/90-docker-registry-ui.sh

--- a/static.dockerfile
+++ b/static.dockerfile
@@ -35,6 +35,4 @@ ENV NGINX_PROXY_HEADER_Host '$http_host'
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /usr/app/dist/ /usr/share/nginx/html/
 COPY --from=builder /usr/app/dist/scripts/docker-registry-ui-static.js /usr/share/nginx/html/scripts/docker-registry-ui.js
-COPY bin/entrypoint /bin
-
-ENTRYPOINT entrypoint
+COPY bin/entrypoint /docker-entrypoint.d/90-docker-registry-ui.sh


### PR DESCRIPTION
Use the entrypoint mechanism available in the latest nginx images. This allows the user to execute custom scripts before the server starts.

I hope this doesn't break anything :)