### PR TITLE
Fixed unexpected EOF errors when pulling large images

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -12,6 +12,8 @@ server {
     chunked_transfer_encoding on;
     # required for strict SNI checking: see Issue #70 (https://github.com/Joxit/docker-registry-ui/issues/70)
     proxy_ssl_server_name on;
+    proxy_buffering off;
+    proxy_ignore_headers "X-Accel-Buffering";
 
     location / {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
Large images don't get correctly pushed to the docker registry when using an nginx reverse proxy with proxy_buffering enabled. What happens is pushing the image appears to succeed but when you pull the image, you eventually get an "unexpected EOF" error. Disabling proxy buffering resolves this issue. The images impacting me were about ~10GB.

FIx was found here. https://www.jfrog.com/jira/browse/RTFACT-16398?focusedCommentId=64722&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-64722