### PR TITLE
Add support for unprivileged user

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,3 +35,5 @@
 - Tomas Hulata [@tombokombo](https://github.com/tombokombo)
 - Ben Jackson [@bjj](https://github.com/bjj)
 - 三十文 [@xfduan](https://github.com/xfduan)
+- Aram Akhavan [@kaysond](https://github.com/kaysond)
+- Jason Tackaberry [@jtackaberry](https://github.com/jtackaberry)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,11 @@ LABEL maintainer="Jones MAGLOIRE @Joxit"
 WORKDIR /usr/share/nginx/html/
 
 ENV NGINX_PROXY_HEADER_Host '$http_host'
+ENV NGINX_LISTEN_PORT '80'
 
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY bin/entrypoint /docker-entrypoint.d/90-docker-registry-ui.sh
 COPY dist/ /usr/share/nginx/html/
 COPY favicon.ico /usr/share/nginx/html/
+
+RUN chown -R nginx:nginx /etc/nginx/ /usr/share/nginx/html/ /var/cache/nginx

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This web user interface uses [Riot](https://github.com/Riot/riot) the react-like
 -   Desactivate add and remove regisitries with `READ_ONLY_REGISTRIES` (see [#219](https://github.com/Joxit/docker-registry-ui/pull/219)).
 -   Filter images and tags with a search bar. You can select the search bar with the shortcut `CRTL` + `F` or `F3`. When the search bar is already focused, the shortcut will fallback to the default behavior (see [#213](https://github.com/Joxit/docker-registry-ui/issues/213)).
 -   **Forward** custom header to your backend registry via environment variable and file via `NGINX_PROXY_PASS_HEADER_*` (see [#206](https://github.com/Joxit/docker-registry-ui/pull/206)).
+-   Run the container with user nginx instead of root via `--user nginx` and listend on custom port via `NGINX_LISTEN_PORT` (see [#224](https://github.com/Joxit/docker-registry-ui/issues/224)).
 
 ## FAQ
 
@@ -81,6 +82,8 @@ Need more informations ? Try my [examples](https://github.com/Joxit/docker-regis
 
 ## Available options
 
+You can run the container with the unprivileged user `nginx`, see the discussion [#224](https://github.com/Joxit/docker-registry-ui/issues/224).
+
 Some env options are available for use this interface for **only one server**.
 
 - `REGISTRY_URL`: The default url of your docker registry. You may need CORS configuration on your registry. This is usually the domain name or IP of your registry reachable by your computer (e.g `http://registry.example.com`). (default: derived from the hostname of your UI).
@@ -93,6 +96,7 @@ Some env options are available for use this interface for **only one server**.
 - `NGINX_PROXY_PASS_URL`: Update the default Nginx configuration and set the **proxy_pass** to your backend docker registry (this avoid CORS configuration). This is usually the name of your registry container in the form `http://registry:5000`.
 - `NGINX_PROXY_HEADER_*`: Update the default Nginx configuration and **set custom headers** for your backend docker registry. Only when `NGINX_PROXY_PASS_URL` is used.
 - `NGINX_PROXY_HEADER_*`: Update the default Nginx configuration and **forward custom headers** to your backend docker registry. Only when `NGINX_PROXY_PASS_URL` is used.
+- `NGINX_LISTEN_PORT`: Listen on a port other than 80. (default: `80` when the user is root, `8080` otherwise).
 - `DEFAULT_REGISTRIES`: List of comma separated registry URLs (e.g `http://registry.example.com,http://registry:5000`), available only when `SINGLE_REGISTRY=false`. (default: ` `).
 - `READ_ONLY_REGISTRIES`: Desactivate dialog for remove and add new registries, available only when `SINGLE_REGISTRY=false`. (default: `false`).
 

--- a/arm32v7.dockerfile
+++ b/arm32v7.dockerfile
@@ -19,8 +19,11 @@ LABEL maintainer="Jones MAGLOIRE @Joxit"
 WORKDIR /usr/share/nginx/html/
 
 ENV NGINX_PROXY_HEADER_Host '$http_host'
+ENV NGINX_LISTEN_PORT '80'
 
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY bin/entrypoint /docker-entrypoint.d/90-docker-registry-ui.sh
 COPY dist/ /usr/share/nginx/html/
 COPY favicon.ico /usr/share/nginx/html/
+
+RUN chown -R nginx:nginx /etc/nginx/ /usr/share/nginx/html/ /var/cache/nginx

--- a/arm64v8.dockerfile
+++ b/arm64v8.dockerfile
@@ -19,8 +19,11 @@ LABEL maintainer="Jones MAGLOIRE @Joxit"
 WORKDIR /usr/share/nginx/html/
 
 ENV NGINX_PROXY_HEADER_Host '$http_host'
+ENV NGINX_LISTEN_PORT '80'
 
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY bin/entrypoint /docker-entrypoint.d/90-docker-registry-ui.sh
 COPY dist/ /usr/share/nginx/html/
 COPY favicon.ico /usr/share/nginx/html/
+
+RUN chown -R nginx:nginx /etc/nginx/ /usr/share/nginx/html/ /var/cache/nginx

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -54,3 +54,13 @@ if [ -n "${NGINX_PROXY_PASS_URL}" ] ; then
   sed -i "s^\${NGINX_PROXY_PASS_HEADERS}^$(get_nginx_proxy_pass_headers)^" /etc/nginx/conf.d/default.conf
   sed -i "s,#!,," /etc/nginx/conf.d/default.conf
 fi
+
+if [ "$(whoami)" != "root" ]; then
+  if [ "$NGINX_LISTEN_PORT" = 80 ]; then
+    NGINX_LISTEN_PORT="8080"
+  fi
+  sed -i "/user  nginx;/d" /etc/nginx/nginx.conf
+  sed -i "s,/var/run/nginx.pid,/tmp/nginx.pid," /etc/nginx/nginx.conf
+fi
+
+sed -i "s,listen       80;,listen       $NGINX_LISTEN_PORT;," /etc/nginx/conf.d/default.conf

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -19,8 +19,11 @@ LABEL maintainer="Jones MAGLOIRE @Joxit"
 WORKDIR /usr/share/nginx/html/
 
 ENV NGINX_PROXY_HEADER_Host '$http_host'
+ENV NGINX_LISTEN_PORT '80'
 
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY bin/entrypoint /docker-entrypoint.d/90-docker-registry-ui.sh
 COPY dist/ /usr/share/nginx/html/
 COPY favicon.ico /usr/share/nginx/html/
+
+RUN chown -R nginx:nginx /etc/nginx/ /usr/share/nginx/html/ /var/cache/nginx


### PR DESCRIPTION
With this PR you can run the container as the user `nginx` which do not have root access.
You can also run the server on a custom port with the environment variable  `NGINX_LISTEN_PORT`. Default values are `80` when the user is `root` and `8080` otherwise.

closes #224