### PR TITLE
Add new option `ADD_NO_CACHE_HEADER` on requests to registry server

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Some env options are available for use this interface for **only one server**.
 - `READ_ONLY_REGISTRIES`: Desactivate dialog for remove and add new registries, available only when `SINGLE_REGISTRY=false`. (default: `false`).
 - `SHOW_CATALOG_NB_TAGS`: Show number of tags per images on catalog page. This will produce + nb images requests, not recommended on large registries. (default: `false`).
 - `HISTORY_CUSTOM_LABELS`: Expose custom labels in history page, custom labels will be processed like maintainer label.
+- `USE_CONTROL_CACHE_HEADER`: Use `Control-Cache` header and set to `no-store, no-cache`. This will avoid some issues on multi-arch images (see [#260](https://github.com/Joxit/docker-registry-ui/issues/260)). This option requires registry configuration: `Access-Control-Allow-Headers` with `Cache-Control`. (default: `false`).
 
 There are some examples with [docker-compose](https://docs.docker.com/compose/) and docker-registry-ui as proxy [here](https://github.com/Joxit/docker-registry-ui/tree/main/examples/ui-as-proxy/) or docker-registry-ui as standalone [here](https://github.com/Joxit/docker-registry-ui/tree/main/examples/ui-as-standalone/).
 
@@ -128,7 +129,7 @@ http:
   headers:
     Access-Control-Allow-Origin: ['http://registry.example.com']
     Access-Control-Allow-Credentials: [true]
-    Access-Control-Allow-Headers: ['Authorization', 'Accept']
+    Access-Control-Allow-Headers: ['Authorization', 'Accept', 'Cache-Control']
     Access-Control-Allow-Methods: ['HEAD', 'GET', 'OPTIONS'] # Optional
 ```
 
@@ -150,7 +151,7 @@ And you need to add these HEADERS:
 http:
   headers:
     Access-Control-Allow-Methods: ['HEAD', 'GET', 'OPTIONS', 'DELETE']
-    Access-Control-Allow-Headers: ['Authorization', 'Accept']
+    Access-Control-Allow-Headers: ['Authorization', 'Accept', 'Cache-Control']
     Access-Control-Expose-Headers: ['Docker-Content-Digest']
 ```
 
@@ -178,7 +179,7 @@ http:
     X-Content-Type-Options: [nosniff]
     Access-Control-Allow-Origin: ['http://127.0.0.1:8000']
     Access-Control-Allow-Methods: ['HEAD', 'GET', 'OPTIONS', 'DELETE']
-    Access-Control-Allow-Headers: ['Authorization', 'Accept']
+    Access-Control-Allow-Headers: ['Authorization', 'Accept', 'Cache-Control']
     Access-Control-Max-Age: [1728000]
     Access-Control-Allow-Credentials: [true]
     Access-Control-Expose-Headers: ['Docker-Content-Digest']

--- a/bin/90-docker-registry-ui.sh
+++ b/bin/90-docker-registry-ui.sh
@@ -10,6 +10,7 @@ sed -i "s~\${DEFAULT_REGISTRIES}~${DEFAULT_REGISTRIES}~" index.html
 sed -i "s~\${READ_ONLY_REGISTRIES}~${READ_ONLY_REGISTRIES}~" index.html
 sed -i "s~\${SHOW_CATALOG_NB_TAGS}~${SHOW_CATALOG_NB_TAGS}~" index.html
 sed -i "s~\${HISTORY_CUSTOM_LABELS}~${HISTORY_CUSTOM_LABELS}~" index.html
+sed -i "s~\${USE_CONTROL_CACHE_HEADER}~${USE_CONTROL_CACHE_HEADER}~" index.html
 
 if [ -z "${DELETE_IMAGES}" ] || [ "${DELETE_IMAGES}" = false ] ; then
   sed -i "s/\${DELETE_IMAGES}/false/" index.html

--- a/src/components/docker-registry-ui.riot
+++ b/src/components/docker-registry-ui.riot
@@ -52,6 +52,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           on-notify="{ notifySnackbar }"
           filter-results="{ state.filter }"
           on-authentication="{ onAuthentication }"
+          use-control-cache-header="{ truthy(props.useControlCacheHeader) }"
         ></tag-list>
       </route>
       <route path="{baseRoute}taghistory/(.*)">
@@ -65,6 +66,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           on-notify="{ notifySnackbar }"
           on-authentication="{ onAuthentication }"
           history-custom-labels="{ stringToArray(props.historyCustomLabels) }"
+          use-control-cache-header="{ truthy(props.useControlCacheHeader) }"
         ></tag-history>
       </route>
     </router>
@@ -133,6 +135,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         this.state.name = props.name || stripHttps(props.registryUrl);
         this.state.catalogElementsLimit = props.catalogElementsLimit || 100000;
         this.state.pullUrl = this.pullUrl(this.state.registryUrl, props.pullUrl);
+        this.state.useControlCacheHeader = props.useControlCacheHeader;
       },
       onServerChange(registryUrl) {
         this.update({

--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -57,6 +57,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           registryUrl: props.registryUrl,
           onNotify: props.onNotify,
           onAuthentication: props.onAuthentication,
+          useControlCacheHeader: props.useControlCacheHeader,
         });
         state.image.fillInfo();
       },
@@ -66,7 +67,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       },
       onTabChanged(arch, idx) {
         const state = this.state;
-        const { registryUrl, onNotify } = this.props;
+        const { registryUrl, onNotify, useControlCacheHeader } = this.props;
         state.elements = [];
         state.image.variants[idx] =
           state.image.variants[idx] ||
@@ -74,6 +75,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             list: false,
             registryUrl,
             onNotify,
+            useControlCacheHeader,
           });
         if (state.image.variants[idx].blobs) {
           return this.processBlobs(state.image.variants[idx].blobs);

--- a/src/components/tag-list/tag-list.riot
+++ b/src/components/tag-list/tag-list.riot
@@ -95,6 +95,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                     registryUrl: props.registryUrl,
                     onNotify: props.onNotify,
                     onAuthentication: props.onAuthentication,
+                    useControlCacheHeader: props.useControlCacheHeader,
                   })
               )
               .sort(compare);

--- a/src/index.html
+++ b/src/index.html
@@ -46,6 +46,7 @@
       read-only-registries="${READ_ONLY_REGISTRIES}"
       show-catalog-nb-tags="${SHOW_CATALOG_NB_TAGS}"
       history-custom-labels="${HISTORY_CUSTOM_LABELS}"
+      use-control-cache-header="${USE_CONTROL_CACHE_HEADER}"
     >
     </docker-registry-ui>
     <!-- endbuild -->
@@ -60,6 +61,7 @@
       single-registry="false"
       show-catalog-nb-tags="true"
       history-custom-labels="first_custom_labels,second_custom_labels"
+      use-control-cache-header="false"
     >
     </docker-registry-ui>
     <!-- endbuild -->


### PR DESCRIPTION
## Background

I'm facing some issues with registry server cache control (see https://github.com/Joxit/docker-registry-ui/issues/260#issuecomment-1239543652)

The docker registry UI is built on top of the registry server API v2 and it implements some HTTP specs incorrectly. This time I'm talking about cache control and [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag).

As I speak, when you are requesting a resource such as a tag manifest (e.g. `/v2/nginx/manifests/1.23`) and your browser cache control is activated, you will get a ETag in the response. When you use this ETag in `If-None-Match` header, you will receive 304 even if your headers and the body have changed.

```sh
# Will return 200 OK
curl -I 'http://127.0.0.1:5000/v2/nginx/manifests/1.23' -H 'Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.imaget.list.v2+json'

# Take the value in the ETag and replace the If-None-Match bellow
# This will return 304 Not Modified
curl -I 'http://127.0.0.1:5000/v2/nginx/manifests/1.23' -H 'Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.imaget.list.v2+json' -H 'If-None-Match: "sha256:b95a99feebf7797479e0c5eb5ec0bdfa5d9f504bc94da550c2f58e839ea6914f"'

# Remove the value application/vnd.oci.imaget.list.v2+json from Accept will still return 304 Not Modified...
curl -I 'http://127.0.0.1:5000/v2/nginx/manifests/1.23' -H 'Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' -H 'If-None-Match: "sha256:b95a99feebf7797479e0c5eb5ec0bdfa5d9f504bc94da550c2f58e839ea6914f"'
```

## How to fix it ?

This issue will be appear on multi-arch images only. With this PR you can add an option  `ADD_NO_CACHE_HEADER=true` on your registry UI and you must add  `Cache-Control` in your registry server `Access-Control-Allow-Headers` configuration.

```yaml
http:
  addr: :5000
  headers:
    X-Content-Type-Options: [nosniff]
    Access-Control-Allow-Origin: ['*']
    Access-Control-Allow-Methods: ['HEAD', 'GET', 'OPTIONS', 'DELETE']
    # This line bellow 
    Access-Control-Allow-Headers: ['Authorization', 'Accept', 'Cache-Control']
    Access-Control-Expose-Headers: ['Docker-Content-Digest']
```

## Try this PR with this image
```
docker pull joxit/docker-registry-ui:feat-no-cache
```