### PR TITLE
support for the docker spec oauth2 token

### DIFF
--- a/src/scripts/http.js
+++ b/src/scripts/http.js
@@ -67,6 +67,8 @@ export class Http {
               }
               if (bearer && bearer.token) {
                 req.setRequestHeader('Authorization', `Bearer ${bearer.token}`);
+              } else if (bearer && bearer.access_token) {
+                req.setRequestHeader('Authorization', `Bearer ${bearer.access_token}`);
               } else {
                 req.withCredentials = true;
               }


### PR DESCRIPTION
The docker spec for authentication using oauth2 refers to the key "access_token". Simple addition to support token responses containing access_token.

https://docs.docker.com/registry/spec/auth/oauth/