### PR TITLE
added missing CORS headers for regular keycloak access via AJAX

### DIFF
--- a/examples/token-auth-keycloak/conf/proxy/nginx.conf
+++ b/examples/token-auth-keycloak/conf/proxy/nginx.conf
@@ -62,6 +62,11 @@ server {
         add_header WWW-Authenticate 'Basic realm="Keycloak login"' always;
         return 401;
       }
+
+      add_header Access-Control-Allow-Origin $http_origin always;
+      add_header Access-Control-Allow-Methods "OPTIONS, GET" always;
+      add_header Access-Control-Allow-Headers "Content-Type, Accept, Authorization" always;
+      add_header Access-Control-Allow-Credentials true always;
       proxy_pass $keycloak;
     }
 


### PR DESCRIPTION
You were missing CORS headers for regular access (you only added headers for OPTIONS and if not authorized but they are missing if you are authenticated. Chrome complains then with missing CORS headers)