### PR TITLE
Avoid 400 - Too big request header when cookie is defined

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -5,8 +5,11 @@ server {
     # charset koi8-r;
     # access_log  /var/log/nginx/host.access.log  main;
 
-    # disable any limits to avoid HTTP 413 for large image uploads
+    # disable any limits to avoid HTTP 413 for large image uploads and 400 on large headers (eg: cookie)
     client_max_body_size 0;
+    client_body_buffer_size     32k;
+    client_header_buffer_size   8k;
+    large_client_header_buffers 8 64k;
 
     # required to avoid HTTP 411: see Issue #1486 (https://github.com/moby/moby/issues/1486)
     chunked_transfer_encoding on;


### PR DESCRIPTION
Support receiving bigger headers and big cookies (sometimes set when reverse proxy is doing some sort of auth)