### PR TITLE
docs(examples): inconsistency of htpasswd file names with docker compose.yml (read-only-auth example)

### DIFF
--- a/examples/read-only-auth/docker-compose.yml
+++ b/examples/read-only-auth/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       - SINGLE_REGISTRY=true
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
-      - ./read-write.htpasswd:/etc/nginx/auth/write.htpasswd:ro
-      - ./read-only.htpasswd:/etc/nginx/auth/read.htpasswd:ro
+      - ./write.htpasswd:/etc/nginx/auth/write.htpasswd:ro
+      - ./read.htpasswd:/etc/nginx/auth/read.htpasswd:ro
     depends_on:
       - registry
     networks:


### PR DESCRIPTION
Hi,

Thank you for this very useful project!

There's a small error in the naming of the authentication files in the read-only-auth example that makes it non-functional.
A very small PR to complete this one https://github.com/Joxit/docker-registry-ui/pull/371 

reproduction of the problem :
```
git clone https://github.com/Joxit/docker-registry-ui
cd docker-registry-ui/examples/read-only-auth/
docker compose up -d
sleep 1
curl 'http://localhost/v2/_catalog?n=1000' -H 'Authorization: Basic aW52YWxpZDppbnZhbGlkCg=='
```

current behavior :
```
Cloning into 'docker-registry-ui'...
remote: Enumerating objects: 4070, done.
remote: Counting objects: 100% (798/798), done.
remote: Compressing objects: 100% (283/283), done.
remote: Total 4070 (delta 552), reused 691 (delta 500), pack-reused 3272 (from 1)
Receiving objects: 100% (4070/4070), 13.95 MiB | 22.71 MiB/s, done.
Resolving deltas: 100% (2724/2724), done.
WARN[0000] /home/user/repositories/github.com/Joxit/docker-registry-ui/examples/read-only-auth/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Running 3/3
 ✔ Network read-only-auth_registry-ui-net  Created                                                           0.1s 
 ✔ Container read-only-auth-registry-1     Started                                                           0.3s 
 ✔ Container read-only-auth-ui-1           Started                                                           0.5s 
<!DOCTYPE html>
<html>
<head>
<title>Error</title>
<style>
html { color-scheme: light dark; }
body { width: 35em; margin: 0 auto;
font-family: Tahoma, Verdana, Arial, sans-serif; }
</style>
</head>
<body>
<h1>An error occurred.</h1>
<p>Sorry, the page you are looking for is currently unavailable.<br/>
Please try again later.</p>
<p>If you are the system administrator of this resource then you should check
the error log for details.</p>
<p><em>Faithfully yours, nginx.</em></p>
</body>
</html>
```

expected behavior :
```
Cloning into 'docker-registry-ui'...
remote: Enumerating objects: 4070, done.
remote: Counting objects: 100% (798/798), done.
remote: Compressing objects: 100% (283/283), done.
remote: Total 4070 (delta 552), reused 691 (delta 500), pack-reused 3272 (from 1)
Receiving objects: 100% (4070/4070), 13.95 MiB | 22.71 MiB/s, done.
Resolving deltas: 100% (2724/2724), done.
WARN[0000] /home/user/repositories/github.com/Joxit/docker-registry-ui/examples/read-only-auth/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Running 3/3
 ✔ Network read-only-auth_registry-ui-net  Created                                                           0.1s 
 ✔ Container read-only-auth-registry-1     Started                                                           0.3s 
 ✔ Container read-only-auth-ui-1           Started                                                           0.5s 
<html>
<head><title>401 Authorization Required</title></head>
<body>
<center><h1>401 Authorization Required</h1></center>
<hr><center>nginx/1.25.3</center>
</body>
</html>
```