### PR TITLE
fix(demo): add missing page title property

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -51,6 +51,7 @@
       show-catalog-nb-tags="true"
       taglist-order=""
       theme="auto"
+      docker-registry-ui-title="Demo Docker Registry UI"
     />
     <script>
       if (localStorage.getItem('registryServer')) {


### PR DESCRIPTION
## Problem: ##
Demo shows a blank page due to error:
`Uncaught TypeError: can't access property "trim", e.props.dockerRegistryUiTitle is undefined`

## Solution: ##
Add missing property `docker-registry-ui-title`

Fixes https://github.com/Joxit/docker-registry-ui/issues/444